### PR TITLE
Tag EC2 instances before starting.

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -27,3 +27,11 @@ kubernetes/kubernetes-server-linux-amd64.tar.gz:
   object_id: da802798-5cd2-4dee-bedd-ac28c233c5fa
   sha: 7b89205ccf43a53636b772747549394fa16a44dd
   size: 368371648
+aws-cli/awscli-bundle.zip:
+  object_id: cdbb9377-d90e-4983-835f-72799d91f362
+  sha: 95b38729dcb07acb692283de7013823e8aa75a9b
+  size: 6879872
+python/Python-2.7.8.tgz:
+  object_id: 3586ff5f-9ae0-4b6b-9b14-fd9ab85da701
+  sha: 511960dd78451a06c9df76509635aeec05b2051a
+  size: 14846119

--- a/jobs/kubernetes-minion/spec
+++ b/jobs/kubernetes-minion/spec
@@ -4,11 +4,13 @@ name: kubernetes-minion
 packages:
 - common
 - kubernetes
+- aws-cli
 
 templates:
   config/env.sh.erb: config/env.sh
   kubelet_ctl.erb: bin/kubelet_ctl
   proxy_ctl.erb: bin/proxy_ctl
+  pre-start.erb: bin/pre-start
 
 properties:
   apiserver.hosts:
@@ -21,3 +23,6 @@ properties:
   cloud-credentials.minion:
     description: K8s cloud provider minion credentials
     default: {}
+
+  aws.cluster-tag:
+    description: K8s cluster tag (AWS only)

--- a/jobs/kubernetes-minion/templates/pre-start.erb
+++ b/jobs/kubernetes-minion/templates/pre-start.erb
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Tag EC2 instances with KubernetesCluster
+# TODO: Revert after https://github.com/cloudfoundry-incubator/bosh-aws-cpi-release/issues/33 is resolved
+
+set -e
+
+source /var/vcap/jobs/kubernetes-minion/config/env.sh
+
+<% if_p('aws.cluster-tag') do %>
+/var/vcap/packages/aws-cli/bin/aws ec2 create-tags \
+  --resources $(curl http://169.254.169.254/latest/meta-data/instance-id) \
+  --tags Key=KubernetesCluster,Value=<%= p('aws.cluster-tag') %>
+<% end %>

--- a/packages/aws-cli/packaging
+++ b/packages/aws-cli/packaging
@@ -1,0 +1,7 @@
+set -e # abort script on any command that exit with a non zero value
+
+unzip aws-cli/awscli-bundle.zip
+
+export PATH=$PATH:/var/vcap/packages/python/bin
+
+./awscli-bundle/install -i $BOSH_INSTALL_TARGET

--- a/packages/aws-cli/spec
+++ b/packages/aws-cli/spec
@@ -1,0 +1,6 @@
+---
+name: aws-cli
+files:
+- aws-cli/awscli-bundle.zip
+dependencies:
+- python

--- a/packages/python/packaging
+++ b/packages/python/packaging
@@ -1,0 +1,25 @@
+set -e # abort script on any command that exit with a non zero value
+
+version="2.7.8"
+echo "Python: ${version}"
+
+name="Python-${version}"
+archive=python/${name}.tgz
+
+if [[ -f ${archive} ]] ; then
+  echo "Archive: ${archive} found"
+else
+  echo "Archive: ${archive} not found"
+  exit 1
+fi
+
+echo "Extracting archive..."
+tar zxf ${archive}
+
+if [[ $? != 0 ]] ; then
+  echo "Archive: ${archive}"
+  exit 1
+fi
+
+cd ${name}
+./configure --prefix=${BOSH_INSTALL_TARGET} && make && make install

--- a/packages/python/spec
+++ b/packages/python/spec
@@ -1,0 +1,4 @@
+---
+name: python
+files:
+- python/Python-2.7.8.tgz


### PR DESCRIPTION
The kubernetes AWS cloud provider associates EC2 instances with subnets
by tagging all resources with the `KubernetesCluster` tag. This patch
tags the EC2 instances provisioned by BOSH before starting jobs. This
should be reverted once BOSH supports adding arbitrary tags in the
deployment manifest.