### PR TITLE
Switch to spruce from spiff.

### DIFF
--- a/generate_deployment_manifest
+++ b/generate_deployment_manifest
@@ -2,8 +2,8 @@
 
 set -e
 
-which spiff > /dev/null 2>&1 || {
-  echo "Aborted. Please install spiff by following https://github.com/cloudfoundry-incubator/spiff#installation" 1>&2
+which spruce > /dev/null 2>&1 || {
+  echo "Aborted. Please install spruce by following https://github.com/geofffranks/spruce#installation" 1>&2
   exit 1
 }
 
@@ -19,7 +19,7 @@ if [ "$infrastructure" != "aws" ] && \
   exit 1
 fi
 
-spiff merge \
+spruce merge \
   "$templates/k8s-deployment.yml" \
   "$templates/k8s-jobs.yml" \
   "$templates/k8s-infrastructure-${infrastructure}.yml" \

--- a/templates/k8s-deployment.yml
+++ b/templates/k8s-deployment.yml
@@ -1,6 +1,7 @@
 ---
 name: kubernetes
-director_uuid: (( merge ))
+
+director_uuid: (( param "please define director uuid" ))
 
 releases:
 - name: kubernetes
@@ -12,9 +13,6 @@ compilation:
   workers: 4
   network: default
   reuse_compilation_vms: false
-  cloud_properties: (( merge ))
-
-resource_pools: (( merge ))
 
 update:
   canaries: 0
@@ -22,8 +20,3 @@ update:
   update_watch_time:  30000-240000
   max_in_flight: 1
   serial: true
-
-networks: (( merge ))
-jobs: (( merge ))
-resource_pools: (( merge ))
-properties: (( merge ))

--- a/templates/k8s-infrastructure-aws.yml
+++ b/templates/k8s-infrastructure-aws.yml
@@ -1,12 +1,10 @@
 meta:
   aws:
-    az: (( merge ))
-
-networks: (( merge ))
+    az: (( param "please define availability zone" ))
 
 compilation:
   cloud_properties:
-    availability_zone: (( meta.aws.az ))
+    availability_zone: (( grab meta.aws.az ))
     instance_type: m3.large
 
 resource_pools:
@@ -16,9 +14,8 @@ resource_pools:
     name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
     version: latest
   cloud_properties:
-    <<: (( merge ))
     instance_type: m3.large
-    availability_zone: (( meta.aws.az ))
+    availability_zone: (( grab meta.aws.az ))
 
 - name: master
   network: default
@@ -26,9 +23,8 @@ resource_pools:
     name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
     version: latest
   cloud_properties:
-    <<: (( merge ))
     instance_type: m3.large
-    availability_zone: (( meta.aws.az ))
+    availability_zone: (( grab meta.aws.az ))
 
 jobs:
 - name: consul
@@ -56,14 +52,11 @@ jobs:
   - name: default
 
 properties:
-  <<: (( merge ))
   apiserver:
-    <<: (( merge ))
-    host: (( jobs.master.networks.default.static_ips.[0] ))
-    hosts: (( jobs.master.networks.default.static_ips ))
+    host: (( grab jobs.master.networks.default.static_ips.[0] ))
+    hosts: (( grab jobs.master.networks.default.static_ips ))
   consul:
-    <<: (( merge ))
-    join_host: (( jobs.consul.networks.default.static_ips.[0] ))
-    join_hosts: (( jobs.consul.networks.default.static_ips ))
+    join_host: (( grab jobs.consul.networks.default.static_ips.[0] ))
+    join_hosts: (( grab jobs.consul.networks.default.static_ips ))
   etcd:
-    machines: (( jobs.master.networks.default.static_ips jobs.minion.networks.default.static_ips ))
+    machines: (( grab jobs.master.networks.default.static_ips jobs.minion.networks.default.static_ips ))

--- a/templates/k8s-infrastructure-warden.yml
+++ b/templates/k8s-infrastructure-warden.yml
@@ -2,74 +2,73 @@ compilation:
   cloud_properties: {}
 
 resource_pools:
-  - name: default
-    network: default
-    stemcell:
-      name: bosh-warden-boshlite-ubuntu-trusty-go_agent
-      version: latest
-    cloud_properties: {}
+- name: default
+  network: default
+  stemcell:
+    name: bosh-warden-boshlite-ubuntu-trusty-go_agent
+    version: latest
+  cloud_properties: {}
 
 networks:
-  - name: default
-    subnets:
-      - range: 10.244.8.4/30
-        reserved: [10.244.8.5]
-        static: [10.244.8.6]
-        cloud_properties: {}
-      - range: 10.244.8.8/30
-        reserved: [10.244.8.9]
-        static: [10.244.8.10]
-        cloud_properties: {}
-      - range: 10.244.8.12/30
-        reserved: [10.244.8.13]
-        static: [10.244.8.14]
-        cloud_properties: {}
-      - range: 10.244.8.16/30
-        reserved: [10.244.8.17]
-        static: [10.244.8.18]
-        cloud_properties: {}
-      - range: 10.244.8.20/30
-        reserved: [10.244.8.21]
-        static: [10.244.8.22]
-        cloud_properties: {}
-      - range: 10.244.8.24/30
-        reserved: [10.244.8.25]
-        static: []
-        cloud_properties: {}
-      - range: 10.244.8.28/30
-        reserved: [10.244.8.29]
-        static: []
-        cloud_properties: {}
-      - range: 10.244.8.32/30
-        reserved: [10.244.8.33]
-        static: []
-        cloud_properties: {}
-      - range: 10.244.8.36/30
-        reserved: [10.244.8.37]
-        static: []
-        cloud_properties: {}
+- name: default
+  subnets:
+  - range: 10.244.8.4/30
+    reserved: [10.244.8.5]
+    static: [10.244.8.6]
+    cloud_properties: {}
+  - range: 10.244.8.8/30
+    reserved: [10.244.8.9]
+    static: [10.244.8.10]
+    cloud_properties: {}
+  - range: 10.244.8.12/30
+    reserved: [10.244.8.13]
+    static: [10.244.8.14]
+    cloud_properties: {}
+  - range: 10.244.8.16/30
+    reserved: [10.244.8.17]
+    static: [10.244.8.18]
+    cloud_properties: {}
+  - range: 10.244.8.20/30
+    reserved: [10.244.8.21]
+    static: [10.244.8.22]
+    cloud_properties: {}
+  - range: 10.244.8.24/30
+    reserved: [10.244.8.25]
+    static: []
+    cloud_properties: {}
+  - range: 10.244.8.28/30
+    reserved: [10.244.8.29]
+    static: []
+    cloud_properties: {}
+  - range: 10.244.8.32/30
+    reserved: [10.244.8.33]
+    static: []
+    cloud_properties: {}
+  - range: 10.244.8.36/30
+    reserved: [10.244.8.37]
+    static: []
+    cloud_properties: {}
 
 jobs:
-  - name: master
-    instances: 1
-    networks:
-      - name: default
-        static_ips: (( static_ips(0) ))
-  - name: minion
-    instances: 2
-    networks:
-      - name: default
-        static_ips: (( static_ips(1, 2) ))
-  - name: guestbook-example
-    lifecycle: errand
-    instances: 1
-    networks:
-      - name: default
+- name: master
+  instances: 1
+  networks:
+  - name: default
+    static_ips: (( static_ips(0) ))
+- name: minion
+  instances: 2
+  networks:
+  - name: default
+    static_ips: (( static_ips(1, 2) ))
+- name: guestbook-example
+  lifecycle: errand
+  instances: 1
+  networks:
+  - name: default
 
 properties:
-  <<: (( merge ))
   apiserver:
-    host: (( jobs.master.networks.default.static_ips.[0] ))
-    hosts: (( jobs.master.networks.default.static_ips ))
+    host: (( grab jobs.master.networks.default.static_ips.[0] ))
+    hosts: (( grab jobs.master.networks.default.static_ips ))
   etcd:
-    machines: (( jobs.master.networks.default.static_ips jobs.minion.networks.default.static_ips ))
+    machines: (( grab jobs.master.networks.default.static_ips jobs.minion.networks.default.static_ips ))

--- a/templates/k8s-jobs.yml
+++ b/templates/k8s-jobs.yml
@@ -7,10 +7,9 @@ jobs:
   persistent_disk: 65536
   networks:
   - name: default
-    static_ips: (( merge ))
+    static_ips: (( param "please define static ips" ))
 
 - name: master
-  <<: (( merge ))
   templates:
   - {name: docker, release: kubernetes}
   - {name: etcd, release: kubernetes}
@@ -22,14 +21,13 @@ jobs:
   persistent_disk: 65536
   networks:
   - name: default
-    static_ips: (( merge ))
+    static_ips: (( param "please define static ips" ))
   properties:
     networks:
       apps: default
     manifest-dirs: [/var/vcap/jobs/kubernetes-master/manifests]
 
 - name: minion
-  <<: (( merge ))
   templates:
   - {name: docker, release: kubernetes}
   - {name: etcd, release: kubernetes}
@@ -40,7 +38,7 @@ jobs:
   persistent_disk: 65536
   networks:
   - name: default
-    static_ips: (( merge ))
+    static_ips: (( param "please define static ips" ))
   properties:
     networks:
       apps: default
@@ -70,22 +68,12 @@ jobs:
       apps: default
 
 properties:
-  <<: (( merge ))
-  apiserver: (( merge ))
-  consul:
-    <<: (( merge ))
-    default_recursor: (( merge ))
-    ssl_ca: (( merge ))
-    ssl_cert: (( merge ))
-    ssl_key: (( merge ))
-    domain: kubernetes
-    encrypt: (( merge ))
+  apiserver:
+    hosts: (( param "please define apiserver hosts" ))
   etcd:
-    machines: (( merge ))
+    machines: (( param "please define etcd machines" ))
     require_ssl: false
     peer_require_ssl: false
-  certs: (( merge ))
-  cloud-provider: (( merge || ~ ))
-  cloud-credentials: (( merge || {} ))
-
-resource_pools: (( merge ))
+  certs: {}
+  cloud-provider: ~
+  cloud-credentials: {}


### PR DESCRIPTION
Use spruce so that we can drop random `<<: (( merge ))` stanzas, and for easier job overrides. Used by https://github.com/18F/cg-deploy-kubernetes/pull/10.