### PR TITLE
Separate etcd

### DIFF
--- a/jobs/kubernetes-master/monit
+++ b/jobs/kubernetes-master/monit
@@ -4,7 +4,6 @@ check process apiserver
     with timeout 60 seconds
   stop program "/var/vcap/jobs/kubernetes-master/bin/apiserver_ctl stop"
   group vcap
-  depends on etcd
 
 check process controller-manager
   with pidfile /var/vcap/sys/run/controller-manager/controller-manager.pid
@@ -12,7 +11,6 @@ check process controller-manager
     with timeout 60 seconds
   stop program "/var/vcap/jobs/kubernetes-master/bin/controller-manager_ctl stop"
   group vcap
-  depends on etcd
   depends on apiserver
 
 check process scheduler

--- a/jobs/kubernetes-master/spec
+++ b/jobs/kubernetes-master/spec
@@ -22,6 +22,9 @@ templates:
   scheduler_ctl.erb: bin/scheduler_ctl
 
 properties:
+  etcd.machines:
+    description: List of etcd hosts
+
   apiserver.hosts:
     description: List of master hosts
 

--- a/jobs/kubernetes-master/templates/apiserver_ctl.erb
+++ b/jobs/kubernetes-master/templates/apiserver_ctl.erb
@@ -31,7 +31,7 @@ case $1 in
 --apiserver-count=<%= p('apiserver.hosts').length %> \
 --cert-dir=$CERT_DIR \
 --cloud-provider=<%= p('cloud-provider') %> \
---etcd-servers=<%= p('etcd.machines').map { |h| "#{h}:4001" }.join ',' %> \
+--etcd-servers=<%= p('etcd.machines').map { |h| "http://#{h}:4001" }.join ',' %> \
 --insecure-bind-address=0.0.0.0 \
 --insecure-port=8080 \
 --logtostderr=true \

--- a/jobs/kubernetes-master/templates/apiserver_ctl.erb
+++ b/jobs/kubernetes-master/templates/apiserver_ctl.erb
@@ -31,7 +31,7 @@ case $1 in
 --apiserver-count=<%= p('apiserver.hosts').length %> \
 --cert-dir=$CERT_DIR \
 --cloud-provider=<%= p('cloud-provider') %> \
---etcd-servers=http://127.0.0.1:4001 \
+--etcd-servers=<%= p('etcd.machines').map { |h| "#{h}:4001" }.join ',' %> \
 --insecure-bind-address=0.0.0.0 \
 --insecure-port=8080 \
 --logtostderr=true \

--- a/jobs/kubernetes-minion/monit
+++ b/jobs/kubernetes-minion/monit
@@ -5,7 +5,6 @@ check process kubelet
   stop program "/var/vcap/jobs/kubernetes-minion/bin/kubelet_ctl stop"
   group vcap
   depends on docker
-  depends on etcd
 
 check process proxy
   with pidfile /var/vcap/sys/run/proxy/proxy.pid
@@ -13,4 +12,3 @@ check process proxy
     with timeout 60 seconds
   stop program "/var/vcap/jobs/kubernetes-minion/bin/proxy_ctl stop"
   group vcap
-  depends on etcd

--- a/jobs/kubernetes-minion/templates/drain.erb
+++ b/jobs/kubernetes-minion/templates/drain.erb
@@ -21,11 +21,14 @@ exec 2>> ${LOG_FILE}
 API_HOST=<%= p('apiserver.hosts').select {|ip| ip != addr}.first %>
 NODE_HOST=<%= addr %>
 
-# TODO: Query against kubernetes.io/hostname after https://github.com/kubernetes/kubernetes/issues/31984 is resolved
-QUERY="{range .items[?(.status.addresses[0].address==\"${NODE_HOST}\")]} {.metadata.name} {end}"
-NODE=$(kubectl -s http://${API_HOST}:8080 get nodes -o jsonpath="${QUERY}")
+# only attempt drain if we can communicate with the api host
+if /bin/nc -vz $API_HOST 8080; then 
+	# TODO: Query against kubernetes.io/hostname after https://github.com/kubernetes/kubernetes/issues/31984 is resolved
+	QUERY="{range .items[?(.status.addresses[0].address==\"${NODE_HOST}\")]} {.metadata.name} {end}"
+	NODE=$(kubectl -s http://${API_HOST}:8080 get nodes -o jsonpath="${QUERY}")
 
-for i in {1..5}; do kubectl -s http://${API_HOST}:8080 drain ${NODE} --force && break || sleep 5; done
+	for i in {1..5}; do kubectl -s http://${API_HOST}:8080 drain ${NODE} --force && break || sleep 5; done
+fi
 
 echo 0 >&3
 exit 0

--- a/jobs/kubernetes-minion/templates/kubelet_ctl.erb
+++ b/jobs/kubernetes-minion/templates/kubelet_ctl.erb
@@ -31,7 +31,7 @@ case $1 in
 --allow-privileged=true \
 --port=10250 \
 --hostname_override=<%= addr %> \
---api-servers=<%= p('apiserver.hosts').map { |h| "#{h}:8080" }.join "," %> \
+--api-servers=<%= p('apiserver.hosts').map { |h| "#{h}:8080" }.join ',' %> \
 --cert-dir=$CERT_DIR \
 --logtostderr=true \
 --docker-endpoint=unix:///var/vcap/sys/run/docker/docker.sock \

--- a/jobs/kubernetes-minion/templates/kubelet_ctl.erb
+++ b/jobs/kubernetes-minion/templates/kubelet_ctl.erb
@@ -31,7 +31,7 @@ case $1 in
 --allow-privileged=true \
 --port=10250 \
 --hostname_override=<%= addr %> \
---api-servers=<%= p('apiserver.hosts').map { |h| "#{h}:8080" }.join ',' %> \
+--api-servers=<%= p('apiserver.hosts').map { |h| "http://#{h}:8080" }.join ',' %> \
 --cert-dir=$CERT_DIR \
 --logtostderr=true \
 --docker-endpoint=unix:///var/vcap/sys/run/docker/docker.sock \

--- a/templates/k8s-infrastructure-aws.yml
+++ b/templates/k8s-infrastructure-aws.yml
@@ -71,10 +71,11 @@ jobs:
 properties:
   nodes: (( grab jobs.master.networks.default.static_ips jobs.minion.networks.default.static_ips ))
   apiserver:
+    ip: (( grab jobs.etcd.networks.default.static_ips.[0] ))
     host: (( grab jobs.master.networks.default.static_ips.[0] ))
     hosts: (( grab jobs.master.networks.default.static_ips ))
   consul:
     join_host: (( grab jobs.consul.networks.default.static_ips.[0] ))
     join_hosts: (( grab jobs.consul.networks.default.static_ips ))
   etcd:
-    machines: (( grab jobs.master.networks.default.static_ips jobs.minion.networks.default.static_ips ))
+    machines: (( grab jobs.etcd.networks.default.static_ips ))

--- a/templates/k8s-infrastructure-aws.yml
+++ b/templates/k8s-infrastructure-aws.yml
@@ -1,6 +1,6 @@
 meta:
   aws:
-    az: (( param "please define availability zone" ))
+    az: (( param "specify availability zone" ))
 
 compilation:
   cloud_properties:
@@ -42,19 +42,25 @@ jobs:
   instances: 3
   networks:
   - name: default
-    static_ips: (( static_ips(5, 6, 7) ))
+    static_ips: (( static_ips(0, 1, 2) ))
+
+- name: etcd
+  instances: 3
+  networks:
+  - name: default
+    static_ips: (( static_ips(3, 4, 5) ))
 
 - name: master
   instances: 3
   networks:
   - name: default
-    static_ips: (( static_ips(0, 1, 2) ))
+    static_ips: (( static_ips(6, 7, 8) ))
 
 - name: minion
   instances: 2
   networks:
   - name: default
-    static_ips: (( static_ips(3, 4) ))
+    static_ips: (( static_ips(9, 10) ))
 
 - name: guestbook-example
   lifecycle: errand

--- a/templates/k8s-jobs.yml
+++ b/templates/k8s-jobs.yml
@@ -85,6 +85,7 @@ jobs:
 
 properties:
   apiserver:
+    ip: (( param "specify apiserver host" ))
     hosts: (( param "specify apiserver hosts" ))
   etcd:
     machines: (( param "specify etcd machines" ))

--- a/templates/k8s-jobs.yml
+++ b/templates/k8s-jobs.yml
@@ -7,12 +7,21 @@ jobs:
   persistent_disk: 65536
   networks:
   - name: default
-    static_ips: (( param "please define static ips" ))
+    static_ips: (( param "specify static ips" ))
+
+- name: etcd
+  templates:
+  - {name: etcd, release: kubernetes}
+  instances: 3
+  resource_pool: default
+  persistent_disk: 65536
+  networks:
+  - name: default
+    static_ips: (( param "specify static ips" ))
 
 - name: master
   templates:
   - {name: docker, release: kubernetes}
-  - {name: etcd, release: kubernetes}
   - {name: flannel, release: kubernetes}
   - {name: kubernetes-minion, release: kubernetes}
   - {name: kubernetes-master, release: kubernetes}
@@ -21,16 +30,13 @@ jobs:
   persistent_disk: 65536
   networks:
   - name: default
-    static_ips: (( param "please define static ips" ))
+    static_ips: (( param "specify static ips" ))
   properties:
-    networks:
-      apps: default
     manifest-dirs: [/var/vcap/jobs/kubernetes-master/manifests]
 
 - name: minion
   templates:
   - {name: docker, release: kubernetes}
-  - {name: etcd, release: kubernetes}
   - {name: flannel, release: kubernetes}
   - {name: kubernetes-minion, release: kubernetes}
   instances: 3
@@ -38,10 +44,7 @@ jobs:
   persistent_disk: 65536
   networks:
   - name: default
-    static_ips: (( param "please define static ips" ))
-  properties:
-    networks:
-      apps: default
+    static_ips: (( param "specify static ips" ))
 
 - name: create-kubernetes-dns
   lifecycle: errand
@@ -51,9 +54,6 @@ jobs:
   resource_pool: default
   networks:
   - name: default
-  properties:
-    networks:
-      apps: default
 
 - name: create-kubernetes-monitoring
   lifecycle: errand
@@ -63,9 +63,6 @@ jobs:
   resource_pool: default
   networks:
   - name: default
-  properties:
-    networks:
-      apps: default
 
 - name: apply-kubernetes-manifests
   lifecycle: errand
@@ -75,9 +72,6 @@ jobs:
   resource_pool: default
   networks:
   - name: default
-  properties:
-    networks:
-      apps: default
 
 - name: guestbook-example
   lifecycle: errand
@@ -88,15 +82,12 @@ jobs:
   resource_pool: default
   networks:
   - name: default
-  properties:
-    networks:
-      apps: default
 
 properties:
   apiserver:
-    hosts: (( param "please define apiserver hosts" ))
+    hosts: (( param "specify apiserver hosts" ))
   etcd:
-    machines: (( param "please define etcd machines" ))
+    machines: (( param "specify etcd machines" ))
     require_ssl: false
     peer_require_ssl: false
   certs: {}


### PR DESCRIPTION
Run etcd on separate hosts from kubernetes components, as recommended in coreos docs: https://coreos.com/kubernetes/docs/latest/getting-started.html. For reasons I still don't totally understand, running etcd on the master and minion hosts made it difficult to restart the cluster without lots of hard-to-diagnose failures.

@cnelson 