### PR TITLE
Pass arbitrary args to kube2consul.

### DIFF
--- a/jobs/kubernetes-master/spec
+++ b/jobs/kubernetes-master/spec
@@ -60,6 +60,12 @@ properties:
   consul.agent_key:
     description: Consul agent private key
 
+  kube2consul.args:
+    description: "Hash of kube2consul arguments"
+    example:
+      kube-sync: 600
+    default: {}
+
   cloud-provider:
     description: K8s cloud provider
     default: ""

--- a/jobs/kubernetes-master/templates/manifests/kube2consul.yml.erb
+++ b/jobs/kubernetes-master/templates/manifests/kube2consul.yml.erb
@@ -32,6 +32,9 @@ spec:
     - /kube2consul
     - -consul-agent=http://127.0.0.1:8500
     - -kube_master_url=http://127.0.0.1:8080
+<% p("kube2consul.args").each do |key, value| %>
+    - -<%= key %>=<% value %>
+<% end %>
   volumes:
   - name: secrets
     hostPath:


### PR DESCRIPTION
So that we can pass options like `kube-sync` and `consul-sync`.