### PR TITLE
[WIP] Update heapster to latest.

### DIFF
--- a/jobs/create-kubernetes-monitoring/templates/manifests/heapster-controller.yaml.erb
+++ b/jobs/create-kubernetes-monitoring/templates/manifests/heapster-controller.yaml.erb
@@ -1,73 +1,51 @@
 <%
-  base_metrics_memory = '140Mi'
-  metrics_memory = base_metrics_memory
-  base_metrics_cpu = '80m'
-  metrics_cpu = base_metrics_cpu
-  base_eventer_memory = '190Mi'
-  eventer_memory = base_eventer_memory
+  base_metrics_memory = "140Mi"
+  base_metrics_cpu = "80m"
+  base_eventer_memory = "190Mi"
   metrics_memory_per_node = 4
   metrics_cpu_per_node = 0.5
   eventer_memory_per_node = 500
   num_nodes = p('nodes').length
-  nanny_memory = '90Mi'
+  nanny_memory = "90Mi"
   nanny_memory_per_node = 200
   if num_nodes >= 0
-    metrics_memory = "#{200 + num_nodes * metrics_memory_per_node}Mi"
-    metrics_cpu = "#{80 + num_nodes * metrics_cpu_per_node}m"
-    eventer_memory = "#{200 * 1024 + num_nodes * eventer_memory_per_node}Ki"
-    nanny_memory = "#{90 * 1024 + num_nodes * nanny_memory_per_node}Ki"
+    nanny_memory = (90 * 1024 + num_nodes * nanny_memory_per_node)|string + "Ki"
   end
 %>
 
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: heapster-v1.2.0-beta.1
+  name: heapster-v1.2.0
   namespace: kube-system
   labels:
     k8s-app: heapster
     kubernetes.io/cluster-service: "true"
-    version: v1.2.0-beta.1
+    version: v1.2.0
 spec:
   replicas: 1
   selector:
     matchLabels:
       k8s-app: heapster
-      version: v1.2.0-beta.1
+      version: v1.2.0
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v1.2.0-beta.1
+        version: v1.2.0
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
     spec:
       containers:
-        - image: gcr.io/google_containers/heapster:v1.2.0-beta.1
+        - image: gcr.io/google_containers/heapster:v1.2.0
           name: heapster
-          resources:
-            # keep request = limit to keep this container in guaranteed class
-            limits:
-              cpu: <%= metrics_cpu %>
-              memory: <%= metrics_memory %>
-            requests:
-              cpu: <%= metrics_cpu %>
-              memory: <%= metrics_memory %>
           command:
             - /heapster
             - --source=kubernetes.summary_api:''
             - --sink=<%= p('heapster.sink') %>
-        - image: gcr.io/google_containers/heapster:v1.2.0-beta.1
+        - image: gcr.io/google_containers/heapster:v1.2.0
           name: eventer
-          resources:
-            # keep request = limit to keep this container in guaranteed class
-            limits:
-              cpu: 100m
-              memory: <%= eventer_memory %>
-            requests:
-              cpu: 100m
-              memory: <%= eventer_memory %>
           command:
             - /eventer
             - --source=kubernetes:''
@@ -97,7 +75,7 @@ spec:
             - --memory=<%= base_metrics_memory %>
             - --extra-memory=<%= metrics_memory_per_node %>Mi
             - --threshold=5
-            - --deployment=heapster-v1.2.0-beta.1
+            - --deployment=heapster-v1.2.0
             - --container=heapster
             - --poll-period=300000
             - --estimator=exponential
@@ -126,7 +104,7 @@ spec:
             - --memory=<%= base_eventer_memory %>
             - --extra-memory=<%= eventer_memory_per_node %>Ki
             - --threshold=5
-            - --deployment=heapster-v1.2.0-beta.1
+            - --deployment=heapster-v1.2.0
             - --container=eventer
             - --poll-period=300000
             - --estimator=exponential


### PR DESCRIPTION
Update deploy manifest based on
https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/cluster-monitoring.

Probably worth updating heapster before we revisit k8s monitoring @cnelson 