### PR TITLE
Skip uncordon on unschedulable nodes.

### DIFF
--- a/jobs/kubernetes-minion/templates/post-start.erb
+++ b/jobs/kubernetes-minion/templates/post-start.erb
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+<% if p('schedulable', nil) == false %>
+
 # Uncordon node
 
 set -e
@@ -15,3 +17,5 @@ QUERY="{range .items[?(.status.addresses[0].address==\"${NODE_HOST}\")]} {.metad
 NODE=$(kubectl -s http://${API_HOST}:8080 get nodes -o jsonpath="${QUERY}")
 
 kubectl -s http://${API_HOST}:8080 uncordon ${NODE}
+
+<% end %>


### PR DESCRIPTION
Because it turns out that even nodes that run kubelet with `--register-schedulable=false` become schedulable after running `kubectl uncordon`.