### PR TITLE
Shrink persistent disks

### DIFF
--- a/templates/k8s-jobs.yml
+++ b/templates/k8s-jobs.yml
@@ -4,7 +4,7 @@ jobs:
   - {name: consul, release: consul}
   instances: 3
   resource_pool: default
-  persistent_disk: 65536
+  persistent_disk: 15000
   networks:
   - name: default
     static_ips: (( param "specify static ips" ))
@@ -14,7 +14,7 @@ jobs:
   - {name: etcd, release: kubernetes}
   instances: 3
   resource_pool: etcd
-  persistent_disk: 65536
+  persistent_disk: 15000
   networks:
   - name: default
     static_ips: (( param "specify static ips" ))
@@ -27,7 +27,7 @@ jobs:
   - {name: kubernetes-master, release: kubernetes}
   instances: 3
   resource_pool: master
-  persistent_disk: 65536
+  persistent_disk: 15000
   networks:
   - name: default
     static_ips: (( param "specify static ips" ))
@@ -42,7 +42,7 @@ jobs:
   - {name: kubernetes-minion, release: kubernetes}
   instances: 3
   resource_pool: minion
-  persistent_disk: 65536
+  persistent_disk: 15000
   networks:
   - name: default
     static_ips: (( param "specify static ips" ))


### PR DESCRIPTION
We are currently allocating 65.5GB to each instances, but using no more than 5GB (and frequently less than 1GB).  

This will recover 1.25TB of disk space (which I plan to re-allocate to elasticsearch production)