### PR TITLE
Use separate resource pool for errands.

### DIFF
--- a/templates/k8s-infrastructure-aws.yml
+++ b/templates/k8s-infrastructure-aws.yml
@@ -47,6 +47,15 @@ resource_pools:
     availability_zone: (( grab meta.aws.az ))
     iam_instance_profile: (( param "specify minion instance profile" ))
 
+- name: errand
+  network: default
+  stemcell:
+    name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
+    version: latest
+  cloud_properties:
+    instance_type: m3.large
+    availability_zone: (( grab meta.aws.az ))
+
 jobs:
 - name: consul
   instances: 3

--- a/templates/k8s-jobs.yml
+++ b/templates/k8s-jobs.yml
@@ -54,7 +54,7 @@ jobs:
   templates:
   - {name: create-kubernetes-dns, release: kubernetes}
   instances: 1
-  resource_pool: default
+  resource_pool: errand
   networks:
   - name: default
 
@@ -63,7 +63,7 @@ jobs:
   templates:
   - {name: create-kubernetes-monitoring, release: kubernetes}
   instances: 1
-  resource_pool: default
+  resource_pool: errand
   networks:
   - name: default
 
@@ -72,7 +72,7 @@ jobs:
   templates:
   - {name: apply-kubernetes-manifests, release: kubernetes}
   instances: 1
-  resource_pool: default
+  resource_pool: errand
   networks:
   - name: default
 
@@ -82,7 +82,7 @@ jobs:
   - {name: guestbook-example, release: kubernetes}
   - {name: flannel, release: kubernetes}
   instances: 1
-  resource_pool: default
+  resource_pool: errand
   networks:
   - name: default
 


### PR DESCRIPTION
So that we can set cloud properties for errand vms downstream.

@LinuxBozo 