### PR TITLE
expose event-ttl configuration

### DIFF
--- a/jobs/kubernetes-master/spec
+++ b/jobs/kubernetes-master/spec
@@ -36,6 +36,10 @@ properties:
     description: List of authentication tokens
     default: []
 
+  apiserver.event-ttl:
+    description: How long kubernetes will keep events.  A large setting can negatively impact etcd performance.
+    default: 1h0m0s
+
   certs.ca:
     description: Kubernetes Certificate Authority certificate
 

--- a/jobs/kubernetes-master/spec
+++ b/jobs/kubernetes-master/spec
@@ -37,8 +37,7 @@ properties:
     default: []
 
   apiserver.event-ttl:
-    description: How long kubernetes will keep events.  A large setting can negatively impact etcd performance.
-    default: 1h0m0s
+    description: How long kubernetes will keep events.  A large setting can negatively impact etcd performance. If not specified, will use the kubernetes default.
 
   certs.ca:
     description: Kubernetes Certificate Authority certificate

--- a/jobs/kubernetes-master/templates/apiserver_ctl.erb
+++ b/jobs/kubernetes-master/templates/apiserver_ctl.erb
@@ -26,7 +26,7 @@ case $1 in
     echo $$ > $PIDFILE
 
     exec /var/vcap/packages/kubernetes/bin/kube-apiserver \
-<% if_p('apiserver.event-ttl') do %>--event-ttl=<%= p('apiserver.event-ttl') %> \<% end %>
+<% if_p('apiserver.event-ttl') do %>--event-ttl=<%= p('apiserver.event-ttl') %><% end %> \
 --admission-control=NamespaceLifecycle,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota \
 --allow-privileged=true \
 --anonymous-auth=false \

--- a/jobs/kubernetes-master/templates/apiserver_ctl.erb
+++ b/jobs/kubernetes-master/templates/apiserver_ctl.erb
@@ -26,6 +26,7 @@ case $1 in
     echo $$ > $PIDFILE
 
     exec /var/vcap/packages/kubernetes/bin/kube-apiserver \
+--event-ttl=<%= p('apiserver.event-ttl') %> \
 --admission-control=NamespaceLifecycle,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota \
 --allow-privileged=true \
 --anonymous-auth=false \

--- a/jobs/kubernetes-master/templates/apiserver_ctl.erb
+++ b/jobs/kubernetes-master/templates/apiserver_ctl.erb
@@ -26,7 +26,7 @@ case $1 in
     echo $$ > $PIDFILE
 
     exec /var/vcap/packages/kubernetes/bin/kube-apiserver \
---event-ttl=<%= p('apiserver.event-ttl') %> \
+<% if_p('apiserver.event-ttl') do %>--event-ttl=<%= p('apiserver.event-ttl') %> \<% end %>
 --admission-control=NamespaceLifecycle,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota \
 --allow-privileged=true \
 --anonymous-auth=false \


### PR DESCRIPTION
Having this setting at the default of 1 hour makes debugging issues due to rolling restarts much more difficult than it needs to be. 

 I'd like to increase this to several hours (maybe a day?) so when we are troubleshooting an issue recent events are easily available and we don't have to do the cloudwatch export to s3 dance to get meaningful information about the historical state of a replicaset / pod.

