### PR TITLE
Delete local data on drain if pods have volumes

### DIFF
--- a/jobs/kubernetes-minion/templates/drain.erb
+++ b/jobs/kubernetes-minion/templates/drain.erb
@@ -26,7 +26,7 @@ if /bin/nc -vz $API_HOST 8080; then
   QUERY="{range .items[?(.metadata.labels.kubernetes\.io/hostname==\"${NODE_HOST}\")]} {.metadata.name} {end}"
   NODE=$(kubectl -s http://${API_HOST}:8080 get nodes -o jsonpath="${QUERY}")
 
-  for i in {1..5}; do kubectl -s http://${API_HOST}:8080 drain ${NODE} --force --ignore-daemonsets && break || sleep 5; done
+  for i in {1..5}; do kubectl -s http://${API_HOST}:8080 drain ${NODE} --force --ignore-daemonsets --delete-local-data && break || sleep 5; done
 fi
 
 echo 0 >&3


### PR DESCRIPTION
Seeing this from CloudWatch whenever we try to drain minions with pods on them that have local data.

```
error: pods with local storage (use --delete-local-data to override): some-pod, another-pod
```