### PR TITLE
initial test of os-conf changes.

### DIFF
--- a/templates/k8s-deployment.yml
+++ b/templates/k8s-deployment.yml
@@ -8,6 +8,9 @@ releases:
   version: latest
 - name: consul
   version: latest
+- name: os-conf
+  url: "https://bosh.io/d/github.com/cloudfoundry/os-conf-release?v=22.0.0"
+  sha1: "6946056ad69ae378cb89c9ef76daf66370a7dc6a" 
 
 update:
   canaries: 0

--- a/templates/k8s-jobs.yml
+++ b/templates/k8s-jobs.yml
@@ -11,6 +11,13 @@ instance_groups:
   networks:
   - name: services
     static_ips: (( param "specify static ips for consul instances" ))
+- name: pre-start-script
+  release: os-conf
+  properties:
+    script: |
+      #!/bin/bash
+      apt-get -y remove rsync
+      apt-get -y remove vim
 
 - name: etcd
   jobs:


### PR DESCRIPTION
## Changes proposed in this pull request:
- initial test of removing `vim` and `rsync` using `os-conf`.

## security considerations

Removes `vim` and `rsync` due to CVEs.

Signed-off-by: Mike Lloyd <mike.lloyd@gsa.gov>